### PR TITLE
Fix @dataclass issue in model.py when using Python 3.11

### DIFF
--- a/py_typescript_generator/model/model.py
+++ b/py_typescript_generator/model/model.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from ordered_set import OrderedSet
@@ -9,8 +9,8 @@ from py_typescript_generator.model.py_enum import PyEnum
 
 @dataclass
 class Model:  # todo rename to PyModel
-    classes: OrderedSet[PyClass] = OrderedSet()
-    enums: OrderedSet[PyEnum] = OrderedSet()
+    classes: OrderedSet[PyClass] = field(default_factory=OrderedSet)
+    enums: OrderedSet[PyEnum] = field(default_factory=OrderedSet)
 
     @staticmethod
     def of_classes(classes):


### PR DESCRIPTION
I've been running into this issue in Python 3.11 when using the library, and I was able to reproduce it when running the tests in 3.11.

`mutable default <class 'ordered_set.OrderedSet'> for field enums is not allowed: use default_factory`

This PR should fix that issue.